### PR TITLE
fiovb: change normal output to standard out

### DIFF
--- a/fiovb/host/main.c
+++ b/fiovb/host/main.c
@@ -70,7 +70,7 @@ static int read_persistent_value(const char *s)
 	terminate_tee_session(&ctx);
 
 	if (res == TEEC_SUCCESS) {
-		fprintf(stderr, "%s\n", rsp);
+		fprintf(stdout, "%s\n", rsp);
 		return 0;
 	}
 		


### PR DESCRIPTION
This changes the successful output to the standard output instead of the error output.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>