### PR TITLE
fiovb: host: check privileges at startup

### DIFF
--- a/fiovb/host/main.c
+++ b/fiovb/host/main.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <tee_client_api.h>
 #include <ta_fiovb.h>
@@ -231,6 +232,11 @@ int fiovb_delenv(int argc, char *argv[])
 int main(int argc, char *argv[])
 {
 	char *p, *cmdname = *argv;
+
+	if (geteuid() != 0) {
+		fprintf(stderr, "Invalid access level, please use sudo\n");
+		return EXIT_FAILURE;
+	}
 
 	if ((p = strrchr (cmdname, '/')) != NULL)
 		cmdname = p + 1;


### PR DESCRIPTION
fiovb need root privileges in order to communicate with the op-tee environment. So check the uid via geteuid() before continuing further.

Signed-off-by: Bram Vlerick <bram.vlerick@openpixelsystems.org>