### PR TITLE
[RFC] ta: add support for OTP values

### DIFF
--- a/fiovb/ta/include/ta_fiovb.h
+++ b/fiovb/ta/include/ta_fiovb.h
@@ -13,6 +13,14 @@
 			    "bootupgrade_primary_updated", "bootfirmware_version", \
 			    "is_secondary_boot", "debug"}
 
+#define OTP_PERSIST_VALUE_LIST {"rollback_protection"}
+
+enum persist_value_type {
+	REGULAR = 0,
+	OTP,
+	VENDOR
+};
+
 /*
  * Reads a persistent value corresponding to the given name.
  *


### PR DESCRIPTION
Add support for generic non-vendor OTP values, which can be written only once.