### PR TITLE
cmake: add initial CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required (VERSION 3.2)
+project (optee_fiovb C)
+
+# https://cmake.org/Wiki/CMake_Useful_Variables
+set (CMAKE_TOOLCHAIN_FILE CMakeToolchain.txt)
+
+include(GNUInstallDirs)
+
+add_compile_options (-Wall)
+
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
+file(GLOB dirs *)
+foreach(dir ${dirs})
+	if(EXISTS ${dir}/CMakeLists.txt)
+		add_subdirectory(${dir})
+	endif()
+endforeach()

--- a/fiovb/CMakeLists.txt
+++ b/fiovb/CMakeLists.txt
@@ -1,0 +1,34 @@
+project (fiovb C)
+
+set (SRC host/main.c)
+set (PRINTENV fiovb_printenv)
+set (SETENV fiovb_setenv)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+install (CODE "execute_process( \
+	       COMMAND ${CMAKE_COMMAND} -E create_symlink \
+	       ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/${PROJECT_NAME} \
+	       ${PRINTENV} \
+	       )"
+)
+
+install (CODE "execute_process( \
+	       COMMAND ${CMAKE_COMMAND} -E create_symlink \
+	       ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/${PROJECT_NAME} \
+	       ${SETENV} \
+	       )"
+)
+
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/../${PRINTENV}
+	       ${CMAKE_CURRENT_BINARY_DIR}/../${SETENV}
+	 DESTINATION ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
Add initial CMakeLists files, making possible to use cmake for a build. This helps to integrate CA/TA into builroot-based builds.