### PR TITLE
Vendor Variables Fix

### DIFF
--- a/fiovb/Makefile
+++ b/fiovb/Makefile
@@ -3,6 +3,12 @@ export V ?= 0
 HOST_CROSS_COMPILE ?= $(CROSS_COMPILE)
 TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 
+ifdef CFG_FIOVB_VENDOR_CREATE
+ifndef CFG_FIOVB_VENDOR_PREFIX
+$(error CFG_FIOVB_VENDOR_CREATE is set but no CFG_FIOVB_VENDOR_PREFIX was provided)
+endif
+endif
+
 .PHONY: all
 all:
 	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables

--- a/fiovb/ta/entry.c
+++ b/fiovb/ta/entry.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2018, Linaro Limited */
 /* Copyright (c) 2019, Foundries.IO */
 
+#include <config.h>
 #include <ta_fiovb.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
@@ -263,7 +264,14 @@ static TEE_Result write_persist_value(uint32_t pt,
 	TEE_MemMove(value, params[1].memref.buffer,
 		    value_sz);
 
-	if (strncmp(name_buf, BOOTFIRM_VER, strlen(BOOTFIRM_VER))) {
+	if (!strncmp(name_buf, vendor_prefix, strlen(vendor_prefix)) &&
+	    !IS_ENABLED(CFG_FIOVB_VENDOR_CREATE)) {
+		res = TEE_ERROR_BAD_PARAMETERS;
+
+		/* Don't create vendor variables */
+		EMSG("Can't create object '%s', CFG_FIOVB_VENDOR_CREATE not set",
+		     name_buf);
+	} else if (strncmp(name_buf, BOOTFIRM_VER, strlen(BOOTFIRM_VER))) {
 		res = write_value(name_buf, name_buf_sz,
 				  value, value_sz, overwrite);
 	} else {


### PR DESCRIPTION
We only want to create the vendor object if `CFG_FIOVB_VENDOR_CREATE` is set. `flags` are used to provide the attributes of the object; they don’t prevent the object from being created.

We also only want a vendor object to be considered valid if `CFG_FIOVB_VENDOR_PREFIX` is set, otherwise `vendor_` will be considered a valid value and an object `vendor_var` could be created.